### PR TITLE
update README, remove stale comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # webex-node-bot-framework
 
-### Node JS framework for Cisco Webex 
+### Webex Teams Bot Framework for Node JS
 
-This project is inspired by, and provides an alternate implementation of, the awesome [node-flint](https://github.com/flint-bot/flint/) framework by [Nick Marus](https://github.com/nmarus).  The framework makes it easy to quickly develop a Webex messaging bot, abstracting away some of the complexity of Webex For Developers interfaces, such as registering for events and calling REST APIs. A bot developer can use the framework to focus primarily on how the bot will interact with users in Webex Teams, by writing "handlers" for various message or membership events in spaces where the bot has been added.
+This project is inspired by, and provides an alternate implementation of, the awesome [node-flint](https://github.com/flint-bot/flint/) framework by [Nick Marus](https://github.com/nmarus).  The framework makes it easy to quickly develop a Webex Teams bot, abstracting away some of the complexity of Webex For Developers interfaces, such as registering for events and calling REST APIs. A bot developer can use the framework to focus primarily on how the bot will interact with users in Webex Teams, by writing "handlers" for various message or membership events in spaces where the bot has been added.
 
 The primary change in this implementation is that it is based on the [webex-jssdk](https://webex.github.io/webex-js-sdk) which continues to be supported as new features and functionality are added to Webex.  
 
 For developers who are familiar with flint, or who wish to port existing bots built on node-flint to the webex-node-bot-framework, this implementation is NOT backwards compatible.  Please see [Migrating from the original flint framework](./docs/migrate-from-node-flint.md)
 
-Feel free to join the ["Webex Node Bot Framework" space on Webex](https://eurl.io/#BJ7gmlSeU) to ask questions and share tips on how to leverage this framework.
+Feel free to join the ["Webex Node Bot Framework" space on Webex Teams](https://eurl.io/#BJ7gmlSeU) to ask questions and share tips on how to leverage this framework.
 
 ## News
 * May, 2020 - Version 2 introduces a some new configuration options designed to help developers restrict access to their bot.   This can be helpful during the development phase (`guideEmails` parameter) or for production bots that should be restricted for use to users that have certain email domains (`restrictedToEmailDomains` parameter).   See [Membership-Rules README](./docs/membership-rules-readme.md)
@@ -1081,6 +1081,9 @@ framework.hears('/file', function(bot, trigger) {
 
 ### bot.reply(replyTo, message, [format]) ⇒ <code>Promise.&lt;Message&gt;</code>
 Send a threaded message reply
+
+NOTE:  Posting a threaded message response via API is currently a Webex EFT feature.  This method WILL FAIL
+if your application identity is not configured for EFT access
 
 **Kind**: instance method of [<code>Bot</code>](#Bot)  
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # webex-node-bot-framework
 
-### Webex Teams Bot Framework for Node JS
+### Node JS Bot Framework for Cisco Webex
 
-This project is inspired by, and provides an alternate implementation of, the awesome [node-flint](https://github.com/flint-bot/flint/) framework by [Nick Marus](https://github.com/nmarus).  The framework makes it easy to quickly develop a Webex Teams bot, abstracting away some of the complexity of Webex For Developers interfaces, such as registering for events and calling REST APIs. A bot developer can use the framework to focus primarily on how the bot will interact with users in Webex Teams, by writing "handlers" for various message or membership events in spaces where the bot has been added.
+This project is inspired by, and provides an alternate implementation of, the awesome [node-flint](https://github.com/flint-bot/flint/) framework by [Nick Marus](https://github.com/nmarus).  The framework makes it easy to quickly develop a Webex messaging bot, abstracting away some of the complexity of Webex For Developers interfaces, such as registering for events and calling REST APIs. A bot developer can use the framework to focus primarily on how the bot will interact with users in Webex, by writing "handlers" for various message or membership events in spaces where the bot has been added.
 
 The primary change in this implementation is that it is based on the [webex-jssdk](https://webex.github.io/webex-js-sdk) which continues to be supported as new features and functionality are added to Webex.  
 
 For developers who are familiar with flint, or who wish to port existing bots built on node-flint to the webex-node-bot-framework, this implementation is NOT backwards compatible.  Please see [Migrating from the original flint framework](./docs/migrate-from-node-flint.md)
 
-Feel free to join the ["Webex Node Bot Framework" space on Webex Teams](https://eurl.io/#BJ7gmlSeU) to ask questions and share tips on how to leverage this framework.
+Feel free to join the ["Webex Node Bot Framework" space on Webex](https://eurl.io/#BJ7gmlSeU) to ask questions and share tips on how to leverage this framework.
 
 ## News
 * May, 2020 - Version 2 introduces a some new configuration options designed to help developers restrict access to their bot.   This can be helpful during the development phase (`guideEmails` parameter) or for production bots that should be restricted for use to users that have certain email domains (`restrictedToEmailDomains` parameter).   See [Membership-Rules README](./docs/membership-rules-readme.md)
@@ -1081,9 +1081,6 @@ framework.hears('/file', function(bot, trigger) {
 
 ### bot.reply(replyTo, message, [format]) ⇒ <code>Promise.&lt;Message&gt;</code>
 Send a threaded message reply
-
-NOTE:  Posting a threaded message response via API is currently a Webex EFT feature.  This method WILL FAIL
-if your application identity is not configured for EFT access
 
 **Kind**: instance method of [<code>Bot</code>](#Bot)  
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # webex-node-bot-framework
 
-### Webex Teams Bot Framework for Node JS
+### Node JS framework for Cisco Webex 
 
-This project is inspired by, and provides an alternate implementation of, the awesome [node-flint](https://github.com/flint-bot/flint/) framework by [Nick Marus](https://github.com/nmarus).  The framework makes it easy to quickly develop a Webex Teams bot, abstracting away some of the complexity of Webex For Developers interfaces, such as registering for events and calling REST APIs. A bot developer can use the framework to focus primarily on how the bot will interact with users in Webex Teams, by writing "handlers" for various message or membership events in spaces where the bot has been added.
+This project is inspired by, and provides an alternate implementation of, the awesome [node-flint](https://github.com/flint-bot/flint/) framework by [Nick Marus](https://github.com/nmarus).  The framework makes it easy to quickly develop a Webex messaging bot, abstracting away some of the complexity of Webex For Developers interfaces, such as registering for events and calling REST APIs. A bot developer can use the framework to focus primarily on how the bot will interact with users in Webex Teams, by writing "handlers" for various message or membership events in spaces where the bot has been added.
 
 The primary change in this implementation is that it is based on the [webex-jssdk](https://webex.github.io/webex-js-sdk) which continues to be supported as new features and functionality are added to Webex.  
 
 For developers who are familiar with flint, or who wish to port existing bots built on node-flint to the webex-node-bot-framework, this implementation is NOT backwards compatible.  Please see [Migrating from the original flint framework](./docs/migrate-from-node-flint.md)
 
-Feel free to join the ["Webex Node Bot Framework" space on Webex Teams](https://eurl.io/#BJ7gmlSeU) to ask questions and share tips on how to leverage this framework.
+Feel free to join the ["Webex Node Bot Framework" space on Webex](https://eurl.io/#BJ7gmlSeU) to ask questions and share tips on how to leverage this framework.
 
 ## News
 * May, 2020 - Version 2 introduces a some new configuration options designed to help developers restrict access to their bot.   This can be helpful during the development phase (`guideEmails` parameter) or for production bots that should be restricted for use to users that have certain email domains (`restrictedToEmailDomains` parameter).   See [Membership-Rules README](./docs/membership-rules-readme.md)
@@ -1081,9 +1081,6 @@ framework.hears('/file', function(bot, trigger) {
 
 ### bot.reply(replyTo, message, [format]) ⇒ <code>Promise.&lt;Message&gt;</code>
 Send a threaded message reply
-
-NOTE:  Posting a threaded message response via API is currently a Webex EFT feature.  This method WILL FAIL
-if your application identity is not configured for EFT access
 
 **Kind**: instance method of [<code>Bot</code>](#Bot)  
 

--- a/docs/header.md
+++ b/docs/header.md
@@ -1,14 +1,14 @@
 # webex-node-bot-framework
 
-### Webex Teams Bot Framework for Node JS
+### Node JS Bot Framework for Cisco Webex
 
-This project is inspired by, and provides an alternate implementation of, the awesome [node-flint](https://github.com/flint-bot/flint/) framework by [Nick Marus](https://github.com/nmarus).  The framework makes it easy to quickly develop a Webex Teams bot, abstracting away some of the complexity of Webex For Developers interfaces, such as registering for events and calling REST APIs. A bot developer can use the framework to focus primarily on how the bot will interact with users in Webex Teams, by writing "handlers" for various message or membership events in spaces where the bot has been added.
+This project is inspired by, and provides an alternate implementation of, the awesome [node-flint](https://github.com/flint-bot/flint/) framework by [Nick Marus](https://github.com/nmarus).  The framework makes it easy to quickly develop a Webex messaging bot, abstracting away some of the complexity of Webex For Developers interfaces, such as registering for events and calling REST APIs. A bot developer can use the framework to focus primarily on how the bot will interact with users in Webex, by writing "handlers" for various message or membership events in spaces where the bot has been added.
 
 The primary change in this implementation is that it is based on the [webex-jssdk](https://webex.github.io/webex-js-sdk) which continues to be supported as new features and functionality are added to Webex.  
 
 For developers who are familiar with flint, or who wish to port existing bots built on node-flint to the webex-node-bot-framework, this implementation is NOT backwards compatible.  Please see [Migrating from the original flint framework](./docs/migrate-from-node-flint.md)
 
-Feel free to join the ["Webex Node Bot Framework" space on Webex Teams](https://eurl.io/#BJ7gmlSeU) to ask questions and share tips on how to leverage this framework.
+Feel free to join the ["Webex Node Bot Framework" space on Webex](https://eurl.io/#BJ7gmlSeU) to ask questions and share tips on how to leverage this framework.
 
 ## News
 * May, 2020 - Version 2 introduces a some new configuration options designed to help developers restrict access to their bot.   This can be helpful during the development phase (`guideEmails` parameter) or for production bots that should be restricted for use to users that have certain email domains (`restrictedToEmailDomains` parameter).   See [Membership-Rules README](./docs/membership-rules-readme.md)

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -1009,9 +1009,6 @@ Bot.prototype.sayWithLocalFile = function (message, filename) {
 /**
  * Send a threaded message reply
  * 
- * NOTE:  Posting a threaded message response via API is currently a Webex EFT feature.  This method WILL FAIL
- * if your application identity is not configured for EFT access
- *
  * @function
  * @param {String|Object} replyTo - MessageId or message object or attachmentAction object to send to reply to.
  * @param {String|Object} message - Message to send to room. This can be a simple string, or a message object for advanced use.


### PR DESCRIPTION
updates "Webex Teams" to "Webex", removes stale comment that is now misleading