### PR TITLE
Fix getPersonByEmail

### DIFF
--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,5 +1,9 @@
 # Version History
 
+## v 2.3.8
+
+* Fix bug in framework.getPersonByEmail helper method
+
 ## v 2.3.7
 
 * Merge PR from jeremywillans to add support for Blockquote in Markdown

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -693,18 +693,7 @@ Framework.prototype.getPersonByEmail = function (personEmail) {
       let personList = people.items;
       let numPeople = personList.length;
       if (numPeople === 1) {
-        person = personList[0];
-        // // Why is this neeeded? 
-        // // person.created = moment(person.created).utc().toDate();
-        // // person.emails = _.forEach(person.emails, email => _.toLower(email));
-        // person.email = person.emails[0];
-        // //person.email = _.toLower(person.emails[0]);
-        // person.username = _.split(_.toLower(person.email), '@', 2)[0];
-        // //person.username = _.split(person.email, '@', 2)[0];
-        // person.domain = _.split(_.toLower(person.email), '@', 2)[1];
-        // //person.domain = _.split(person.email, '@', 2)[1];
-        // person.avatar = person.avatar || '';
-        return when(person);
+        return when(personList[0]);
       } else if (numPeople === 0) {
         when.reject(new Error(`No user found with email: ${personEmail}`));
       } else {


### PR DESCRIPTION
This method is a legacy (from fling) "helper" wrapper to lookup a user by email via the /people API.    Some of these old helpers were not added to the tests and this is one of them.  It looks like JP attempted some cleanup and introduced an undeclared variable.  This fix should address this.