### PR TITLE
Log calls to framework.hears()

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Feel free to join the ["Webex Node Bot Framework" space on Webex](https://eurl.i
   - [Authentication](#authentication)
   - [Storage](#storage)
   - [Bot Accounts](#bot-accounts)
+  - [Troubleshooting](#troubleshooting)
 - [Framework Reference](#framework-reference)
   - [Classes](#classes)
   - [Objects](#objects)
@@ -285,7 +286,6 @@ See [MongoStore](#MongoStore), for details on how to configure this storage adap
 
 The redis adaptor is likely broken and needs to be updated to support the new functions.   It would be great if a flint user of redis wanted to [contribute](./contributing.md)!
 
-
 ## Bot Accounts
 
 **When using "Bot Accounts" the major differences are:**
@@ -307,8 +307,26 @@ symbol and the word. With bot accounts, this behaves a bit differently.
 * If defining a framework.hears() using regex, the trigger.args array is the entire
   message.
 
-# Framework Reference
+## Troubleshooting
 
+A common complaint from new framework developers is "My bot is not responding to  messages!".  If this is happening to you, here are a few things to check:
+
+1. Make sure you have configured your app with the token that belongs to the bot you are sending messages to.
+2. Make sure your framework based app is up and running.
+3. If using webhooks, make sure that your Webhook URL is reachable from the public internet.  If you aren't sure how to test this, remove the `webhookUrl` key from your framework config object.   This will use websockets which are more likely to work in development configurations.
+4. If interacting with a bot in a group space, make sure to at-mention your bot when you send it a message.  Only messages that specifically at-mention a bot by name are sent to the bot logic.
+
+If you are having intermittent problems with your bot failing to respond to messages this may be a problem with the Webex services itself, a problem with the framework, or a problem with the way you have configured your `framework.hears(...)` methods.   One way to isolate the problem is to add a handler for the internal framework log events, as follows
+
+```javascript
+framework.on('log', (msg) => {
+  console.log(msg);
+});
+```
+
+This will cause your app to include framework logging which provides details about every message received, and every `framework.hears()` handler that is invoked in response to those messages.   If you don't see the message you are sending to your bot, contact Webex developer support.  If you do see the message, check the logs to validate that your `framework.hears()` handler is being called.   You may need to modify the phrase. 
+
+# Framework Reference
 
 ## Classes
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -117,7 +117,6 @@ See [MongoStore](#MongoStore), for details on how to configure this storage adap
 
 The redis adaptor is likely broken and needs to be updated to support the new functions.   It would be great if a flint user of redis wanted to [contribute](./contributing.md)!
 
-
 ## Bot Accounts
 
 **When using "Bot Accounts" the major differences are:**
@@ -138,3 +137,22 @@ symbol and the word. With bot accounts, this behaves a bit differently.
 
 * If defining a framework.hears() using regex, the trigger.args array is the entire
   message.
+
+## Troubleshooting
+
+A common complaint from new framework developers is "My bot is not responding to  messages!".  If this is happening to you, here are a few things to check:
+
+1. Make sure you have configured your app with the token that belongs to the bot you are sending messages to.
+2. Make sure your framework based app is up and running.
+3. If using webhooks, make sure that your Webhook URL is reachable from the public internet.  If you aren't sure how to test this, remove the `webhookUrl` key from your framework config object.   This will use websockets which are more likely to work in development configurations.
+4. If interacting with a bot in a group space, make sure to at-mention your bot when you send it a message.  Only messages that specifically at-mention a bot by name are sent to the bot logic.
+
+If you are having intermittent problems with your bot failing to respond to messages this may be a problem with the Webex services itself, a problem with the framework, or a problem with the way you have configured your `framework.hears(...)` methods.   One way to isolate the problem is to add a handler for the internal framework log events, as follows
+
+```javascript
+framework.on('log', (msg) => {
+  console.log(msg);
+});
+```
+
+This will cause your app to include framework logging which provides details about every message received, and every `framework.hears()` handler that is invoked in response to those messages.   If you don't see the message you are sending to your bot, contact Webex developer support.  If you do see the message, check the logs to validate that your `framework.hears()` handler is being called.   You may need to modify the phrase. See the [framework.hears documentation](#Framework+hears)

--- a/docs/version-history.md
+++ b/docs/version-history.md
@@ -1,5 +1,9 @@
 # Version History
 
+## v 2.3.9
+
+* Emit framework log events with details about framework.hears() calls
+
 ## v 2.3.8
 
 * Fix bug in framework.getPersonByEmail helper method

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -1171,6 +1171,7 @@ Framework.prototype.onMessageCreated = function (message) {
 
               // run action
               if ((!membershipRules) || (membershipRules.shouldCallHears(lex, bot, trigger))) {
+                bot.framework.log(`(Hears Called) framework.hears(${lex.phrase},...)`);
                 lex.action(bot, trigger, id);
               }
               return true;
@@ -1189,6 +1190,7 @@ Framework.prototype.onMessageCreated = function (message) {
 
               // run action
               if ((!membershipRules) || (membershipRules.shouldCallHears(lex, bot, trigger))) {
+                bot.framework.log(`(Hears Called) framework.hears("${lex.phrase}",...)`); 
                 lex.action(bot, trigger, id);
               }
               return true;
@@ -1279,7 +1281,7 @@ Framework.prototype.onMessageCreated = function (message) {
         }
 
         // if matched
-        if (matched && typeof this.authorize === 'function') {
+        if (matched.length && typeof this.authorize === 'function') {
           // if authorization function exists...
           return when(this.authorize(bot, trigger, this.id))
             .then(authorized => {
@@ -1296,13 +1298,14 @@ Framework.prototype.onMessageCreated = function (message) {
         }
 
         // else, if matched and no authorization configured, run command
-        else if (matched) {
+        else if (matched.length) {
           runActions(matched, bot, trigger, this);
           return when(trigger);
         }
 
         // else, do nothing...
         else {
+          bot.framework.log(`(No Hears Called!) Does your app need a catch-all handler?`); 
           return when(false);
         }
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webex-node-bot-framework",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "description": "Webex Teams Bot Framework for Node JS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Emit additional framework log events with details about which framework.hears() instances are called in response to messages.   The hope is that this will help developers identify where the problem is when they think that bots are not responding to their messages.